### PR TITLE
fix: update media query styles for experience section

### DIFF
--- a/mediaqueries.css
+++ b/mediaqueries.css
@@ -100,4 +100,23 @@
   .text-container {
     text-align: justify;
   }
+  /* Fix for Experience Section Cards */
+.article-container {
+  flex-direction: column;
+  align-items: center;
+}
+
+article {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  text-align: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.experience-details-container {
+  align-items: center;
+}
 }


### PR DESCRIPTION
This PR fixes a layout issue in the experience section on screens under 600px.

I adjusted the .article-container, article, and .experience-details-container styles in the mobile media query to stack the text in the cards vertically, center them, and remove the inconsistent spacing that was throwing things off.

Really grateful for this tutorial! It taught me a lot and gave me a chance to contribute back. 